### PR TITLE
fix: replace bare except clauses with except Exception

### DIFF
--- a/diffsynth/extensions/FastBlend/api.py
+++ b/diffsynth/extensions/FastBlend/api.py
@@ -78,7 +78,7 @@ def smooth_video(
     # output
     try:
         fps = int(fps)
-    except:
+    except Exception:
         fps = get_video_fps(video_style) if video_style is not None else 30
     print("Fps:", fps)
     print("Saving video...")
@@ -243,7 +243,7 @@ def interpolate_video(
         InterpolationModeRunner().run(frames_guide, frames_style, index_style, batch_size=batch_size, ebsynth_config=ebsynth_config, save_path=output_frames_path)
     try:
         fps = int(fps)
-    except:
+    except Exception:
         fps = 30
     print("Fps:", fps)
     print("Saving video...")

--- a/diffsynth/extensions/ImageQualityMetric/open_clip/tokenizer.py
+++ b/diffsynth/extensions/ImageQualityMetric/open_clip/tokenizer.py
@@ -119,7 +119,7 @@ class SimpleTokenizer(object):
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 

--- a/diffsynth/models/lora.py
+++ b/diffsynth/models/lora.py
@@ -116,7 +116,7 @@ class LoRAFromCivitai:
                             break
                     else:
                         return lora_prefix, model_resource
-                except:
+                except Exception:
                     pass
         return None
 
@@ -251,7 +251,7 @@ class GeneralLoRAFromPeft:
             try:
                 weight_up = state_dict_lora[lora_name_dict[name][0]].to(device=computation_device, dtype=computation_dtype)
                 weight_down = state_dict_lora[lora_name_dict[name][1]].to(device=computation_device, dtype=computation_dtype)
-            except:
+            except Exception:
                 from ipdb import set_trace; set_trace()
             if len(weight_up.shape) == 4:
                 weight_up = weight_up.squeeze(3).squeeze(2)

--- a/diffsynth/models/model_manager.py
+++ b/diffsynth/models/model_manager.py
@@ -141,7 +141,7 @@ def load_model_from_huggingface_folder(file_path, model_names, model_classes, to
             model = model.half()
         try:
             model = model.to(device=device)
-        except:
+        except Exception:
             pass
         loaded_model_names.append(model_name)
         loaded_models.append(model)

--- a/diffsynth/utils/prompt_extend.py
+++ b/diffsynth/utils/prompt_extend.py
@@ -402,7 +402,7 @@ class QwenPromptExpander(PromptExpander):
             )
             try:
                 from .qwen_vl_utils import process_vision_info
-            except:
+            except Exception:
                 from qwen_vl_utils import process_vision_info
             self.process_vision_info = process_vision_info
             min_pixels = 256 * 28 * 28

--- a/diffsynth/utils/utils.py
+++ b/diffsynth/utils/utils.py
@@ -391,13 +391,13 @@ def apply_lora(model, device_to, transformer_load_device, params_to_keep=None, d
                     key = "{}.{}".format(name_no_prefix, param)
                     try:
                         set_module_tensor_to_device(model.model.diffusion_model, key, device=transformer_load_device, dtype=dtype_to_use, value=state_dict[key])
-                    except:
+                    except Exception:
                         continue
                 model.patch_weight_to_device("{}.{}".format(name, param), device_to=device_to)
                 if low_mem_load:
                     try:
                         set_module_tensor_to_device(model.model.diffusion_model, key, device=transformer_load_device, dtype=dtype_to_use, value=model.model.diffusion_model.state_dict()[key])
-                    except:
+                    except Exception:
                         continue
             m.comfy_patched_weights = True
       
@@ -410,7 +410,7 @@ def apply_lora(model, device_to, transformer_load_device, params_to_keep=None, d
                         dtype_to_use = torch.float32
                     try:
                         set_module_tensor_to_device(model.model.diffusion_model, name, device=transformer_load_device, dtype=dtype_to_use, value=state_dict[name])
-                    except:
+                    except Exception:
                         continue
         return model
 
@@ -447,13 +447,13 @@ def apply_lora(model, device_to, transformer_load_device, params_to_keep=None, d
                     key = "{}.{}".format(name_no_prefix, param)
                     try:
                         set_module_tensor_to_device(model.model.diffusion_model, key, device=transformer_load_device, dtype=dtype_to_use, value=state_dict[key])
-                    except:
+                    except Exception:
                         continue
                 model.patch_weight_to_device("{}.{}".format(name, param), device_to=device_to)
                 if low_mem_load:
                     try:
                         set_module_tensor_to_device(model.model.diffusion_model, key, device=transformer_load_device, dtype=dtype_to_use, value=model.model.diffusion_model.state_dict()[key])
-                    except:
+                    except Exception:
                         continue
             m.comfy_patched_weights = True
       
@@ -466,6 +466,6 @@ def apply_lora(model, device_to, transformer_load_device, params_to_keep=None, d
                         dtype_to_use = torch.float32
                     try:
                         set_module_tensor_to_device(model.model.diffusion_model, name, device=transformer_load_device, dtype=dtype_to_use, value=state_dict[name])
-                    except:
+                    except Exception:
                         continue
         return model


### PR DESCRIPTION
Replace 13 bare `except:` across 6 files in `diffsynth/` with `except Exception:` to avoid catching `SystemExit`/`KeyboardInterrupt` during video processing.